### PR TITLE
Setting cms-http-group email to get job alarms

### DIFF
--- a/src/CondorMonitoring/JobCounter.sh
+++ b/src/CondorMonitoring/JobCounter.sh
@@ -15,7 +15,7 @@ if [ -f scriptRunning.run ];
 then
     echo "Last JobCounter.sh is currently running. Will send an email to the admin."
     SUBJECT="[Monitoring] CondorMonitoring running slowly"
-    EMAIL="justas.balcas@cern.ch"
+    EMAIL="cms-http-group@cern.ch"
     touch ./emailmessage.txt
     echo "Hi, Condor monitoring script is running slowly at:" > ./emailmessage.txt
     echo $location >> ./emailmessage.txt


### PR DESCRIPTION
@juztas 

This PR is to replace justas email by  cms-http-group email.
Then it over [PR#14](https://github.com/dmwm/gwmsmon/issues/14)

Best Regards, Lina.